### PR TITLE
Rename project slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# shaded.tiles.tilecloud.io
+# shaded.tiles.geolonia.com
 
 A raster tile based on https://www.naturalearthdata.com/.
 

--- a/source.json
+++ b/source.json
@@ -1,10 +1,10 @@
 {
   "format": "raster",
-  "name": "shaded.tiles.tilecloud.io",
+  "name": "shaded.tiles.geolonia.com",
   "description": "Tiles derived from the public Natural Earth data.",
   "maxzoom": 6,
   "tiles": [
-    "https://shaded.tiles.tilecloud.io/tiles/{z}/{x}/{y}.png"
+    "https://shaded.tiles.geolonia.com/tiles/{z}/{x}/{y}.png"
   ],
   "tileSize": 256
 }


### PR DESCRIPTION
This patch simply renames `tilecloud.io` with `geolonia.com`.